### PR TITLE
Fix orchestrator crashes and unsafe eval() in MultiAgent

### DIFF
--- a/environment/agents/multi.py
+++ b/environment/agents/multi.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import logging
 import re
@@ -98,7 +99,9 @@ Note! Don't output any analysis and explanations!
             if match:
                 intents_list = match.group(0)
                 print("Filtered intents_list：\n", intents_list)
-                return eval(intents_list)
+                # Use literal_eval instead of eval: the string comes from LLM
+                # output, so eval() would execute arbitrary Python code.
+                return ast.literal_eval(intents_list)
             else:
                 raise ValueError("No valid intent list found in response")
         except Exception as e:
@@ -350,7 +353,7 @@ Please Only output pure JSON format:
                             print(f"Intent analysis returned empty list")
                     except Exception as e:
                         logging.warning(f"Intent analysis attempt {attempt + 1} failed: {e}")
-                        if attempt == MAX_Retries:
+                        if attempt == MAX_Retries - 1:
                             logging.error(f"Reached max retries for intent analysis")
                             return 1
             else:
@@ -370,19 +373,22 @@ Please Only output pure JSON format:
                         previous_user_input_graph,
                         graph_reflection
                     )
+                    if not agent_data:
+                        print(f"Agent graph generation returned empty value")
+                        if attempt == MAX_Retries - 1:
+                            logging.error(f"Reached max retries for agent graph generation")
+                            return 1
+                        continue
                     previous_agent_graph = agent_data["Agent Graph"]
                     previous_agent_chain = agent_data["Agent Chain"]
                     previous_user_input_graph = agent_data["User Input Graph"]
-                    if agent_data:
-                        print(f"Agent graph generated successfully")
-                        try:
-                            agent_chain = agent_data["Agent Chain"]
-                            print("First possible execution order:", agent_chain)
-                        except ValueError as e:
-                            print("Error:", e)
-                        break
-                    else:
-                        print(f"Agent graph generation returned empty value")
+                    print(f"Agent graph generated successfully")
+                    try:
+                        agent_chain = agent_data["Agent Chain"]
+                        print("First possible execution order:", agent_chain)
+                    except ValueError as e:
+                        print("Error:", e)
+                    break
                 except Exception as e:
                     logging.warning(f"Agent graph generation attempt {attempt + 1} failed: {e}")
                     if attempt == MAX_Retries - 1:
@@ -444,6 +450,12 @@ Please Only output pure JSON format:
     def run(self):
         requirement = input("User Requirement:")
         result = self.process_requirement(requirement)
+        # process_requirement returns an int (1) instead of a dict when it
+        # fails to converge on a valid plan. Guard against that here so the
+        # program exits cleanly instead of raising a TypeError on lookup.
+        if not isinstance(result, dict):
+            print("Failed to generate a valid agent plan after multiple attempts. Exiting.")
+            return
         agent_graph = result["Agent Graph"]
         agent_chain = result["Agent Chain"]
         user_input_graph = result["User Input Graph"]


### PR DESCRIPTION
## Summary

This PR fixes several bugs in `environment/agents/multi.py` that cause the CLI to crash or behave incorrectly during normal operation. None of them require an LLM/network to trigger — they're plain Python logic errors in the orchestrator.

## Background

`MultiAgent.process_requirement()` drives an LLM-based pipeline (intent analysis → agent-graph generation → graph judgment) with bounded retries/reflections. When it cannot converge on a valid plan it returns the integer `1` (in **4** places). The bugs below all sit on or around that contract.

## Changes

### 1. `run()` crashed on every recoverable pipeline failure (critical)
`process_requirement()` returns the int `1` on failure, but `run()` immediately did:
```python
result = self.process_requirement(requirement)
agent_graph = result["Agent Graph"]   # TypeError: 'int' object is not subscriptable
```
Because the surrounding pipeline can legitimately fail to converge (LLM returns malformed JSON, judgment keeps failing, etc.), this raised `TypeError` and killed the program on otherwise-recoverable failures. Added an `isinstance(result, dict)` guard so it exits cleanly with a message instead.

### 2. `eval()` on raw LLM output (security)
`intents_analysis()` parsed a list literal out of an LLM response and ran `eval()` on it:
```python
match = re.search(r'\[.*\]', response.choices[0].message.content.strip())
...
return eval(intents_list)
```
`eval()` executes arbitrary Python on a string sourced from model output — an injection footgun. Replaced with `ast.literal_eval`, which parses the same list literal while refusing anything that isn't a literal. Malformed output still raises and is caught by the existing handler, so retry behavior is unchanged.

### 3. Dead "max retries" branch in intent analysis (off-by-one)
```python
for attempt in range(MAX_Retries):      # 0 .. MAX_Retries-1
    ...
    except Exception as e:
        if attempt == MAX_Retries:      # never true
            logging.error("Reached max retries for intent analysis")
            return 1
```
`attempt` never equals `MAX_Retries`, so this branch was dead code and the graceful `return 1` never fired. Fixed to `MAX_Retries - 1`, consistent with the graph-generation loop below it.

### 4. `None` return from `generate_agent_graph` was mishandled
In the graph-generation loop, `agent_data` was indexed *before* the `if agent_data:` check:
```python
agent_data = self.generate_agent_graph(...)
previous_agent_graph = agent_data["Agent Graph"]   # TypeError if agent_data is None
...
if agent_data:                                     # dead: already crashed above
```
`generate_agent_graph()` legitimately returns `None` on JSON-validation failure, so this raised `TypeError` (caught by the surrounding `except`, wasting a retry) instead of hitting the intended empty-value branch. Moved the `None`-check ahead of the indexing.

## Verification
- `python -m py_compile environment/agents/multi.py` passes.
- Confirmed `ast.literal_eval` parses a representative intent list `['Loudness Normalization', 'Video to Audio']` identically to `eval`, raises on malformed input (same as before → triggers retry), and refuses a malicious payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)